### PR TITLE
Update 13b. 轻松开始你的第一次 AI 视频总结（API 版）- 精简版.ipynb

### DIFF
--- a/Demos/13b. 轻松开始你的第一次 AI 视频总结（API 版）- 精简版.ipynb
+++ b/Demos/13b. 轻松开始你的第一次 AI 视频总结（API 版）- 精简版.ipynb
@@ -57,7 +57,8 @@
     "!pip install numpy\n",
     "!pip install soundfile\n",
     "!pip install ipywidgets\n",
-    "!pip install librosa"
+    "!pip install librosa\n",
+    "!pip install httpx==0.27.2"
    ]
   },
   {


### PR DESCRIPTION
问题在于colab默认 httpx 更新为 0.28，但是他们删除了不推荐的关键字proxies。

需要将 httpx 降级到 0.27.2 以解决这个问题，否则在# 构建 OpenAI 客户端
client = OpenAI(...
会报错 Client.__init__() got an unexpected keyword argument ‘proxies‘