### PR TITLE
0.15.2 peft LoraCondigUpdate 11. DPO 微调示例：根据人类偏好优化 LLM 大语言模型.md

### DIFF
--- a/Guide/11. DPO 微调示例：根据人类偏好优化 LLM 大语言模型.md
+++ b/Guide/11. DPO 微调示例：根据人类偏好优化 LLM 大语言模型.md
@@ -49,7 +49,7 @@ import pandas as pd
 from tqdm.auto import tqdm
 
 from datasets import Dataset
-from peft import LoraConfig
+from peft import LoraConfig #LoraConfig has been moved under peft.tuners in version 0.15.2 release on Apr 15, 2025
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, GenerationConfig
 from trl import DPOConfig, DPOTrainer
 ```


### PR DESCRIPTION
when I tried to import LoraConfig from peft, it told me I can't import from peft. And I checked peft __init__.py, and found LoraConfig has just been moved under peft.tuners with version==0.15.2 released on Apr 15,2025.